### PR TITLE
Use Pay-as-you-go (Per GB 2018) Log Analytics SKU

### DIFF
--- a/mslearn-analyze-data-in-sentinel/sentinel-template.json
+++ b/mslearn-analyze-data-in-sentinel/sentinel-template.json
@@ -47,7 +47,7 @@
                     "immediatePurgeDataOn30Days": true
                 },
                 "sku": {
-                    "name": "Free"
+                    "name": "PerGB2018"
                 }
             }
         },

--- a/mslearn-hunt-threats-sentinel/sentinel-template.json
+++ b/mslearn-hunt-threats-sentinel/sentinel-template.json
@@ -47,7 +47,7 @@
                     "immediatePurgeDataOn30Days": true
                 },
                 "sku": {
-                    "name": "Free"
+                    "name": "PerGB2018"
                 }
             }
         },

--- a/mslearn-incident-management-sentinel/sentinel-template.json
+++ b/mslearn-incident-management-sentinel/sentinel-template.json
@@ -47,7 +47,7 @@
                     "immediatePurgeDataOn30Days": true
                 },
                 "sku": {
-                    "name": "Free"
+                    "name": "PerGB2018"
                 }
             }
         },

--- a/mslearn-query-data-sentinel/sentinel-template.json
+++ b/mslearn-query-data-sentinel/sentinel-template.json
@@ -47,7 +47,7 @@
                     "immediatePurgeDataOn30Days": true
                 },
                 "sku": {
-                    "name": "Free"
+                    "name": "PerGB2018"
                 }
             }
         },

--- a/mslearn-threat-response-sentinel-playbooks/sentinel-template.json
+++ b/mslearn-threat-response-sentinel-playbooks/sentinel-template.json
@@ -47,7 +47,7 @@
                     "immediatePurgeDataOn30Days": true
                 },
                 "sku": {
-                    "name": "Free"
+                    "name": "PerGB2018"
                 }
             }
         },


### PR DESCRIPTION
Match default Log Analytics pricing tier.
"Free" SKU is no longer available.
Pay-as-you-go is the most suitable for non-production use cases.

This addresses issue #2 and is a superset of PR #3 