### PR TITLE
Fix Azure CXP BUG 145299 - missing resource in ARM template

### DIFF
--- a/mslearn-analyze-data-in-sentinel/sentinel-template.json
+++ b/mslearn-analyze-data-in-sentinel/sentinel-template.json
@@ -52,6 +52,16 @@
             }
         },
         {
+            "type": "Microsoft.SecurityInsights/onboardingStates",
+            "apiVersion": "2022-12-01-preview",
+            "name": "default",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaceName'))]"
+            ],
+            "properties": {},
+            "scope": "[concat('Microsoft.OperationalInsights/workspaces/', parameters('workspaceName'))]"
+        },
+        {
             "type": "Microsoft.OperationsManagement/solutions",
             "apiVersion": "2015-11-01-preview",
             "name": "[concat('SecurityInsights','(', parameters('workspaceName'),')')]",


### PR DESCRIPTION
This template was creating the Sentinel workspace, but it was not onboarded, so the exercise failed for customers. The bug is (AzureCXP)Onboarding Error in Microsoft Sentinel During SC-200 Learning Path. I added the missing resource to the ARM template to fix the issue, but it may need API updates.